### PR TITLE
feat: add group name to topics data model

### DIFF
--- a/src/types/topic.ts
+++ b/src/types/topic.ts
@@ -36,6 +36,7 @@ interface Teaser {
   timestampISO: string;
   user: UserObjectSlim;
   index: number;
+  group_name?: string,
 }
 
 export type TopicObjectSlim = TopicSlimProperties & TopicSlimOptionalProperties;


### PR DESCRIPTION
This PR adds a group_name field to the topics data model and will be used for the #2 feature.