### PR TITLE
feat: track composer plugin

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -93,7 +93,7 @@
         "multiparty": "4.2.3",
         "nconf": "0.12.0",
         "nodebb-plugin-2factor": "5.1.2",
-        "nodebb-plugin-composer-default": "9.2.4",
+        "nodebb-plugin-composer-default": "git://github.com/yliang412/nodebb-plugin-composer-default#op-mod-v9.2.5",
         "nodebb-plugin-dbsearch": "5.1.5",
         "nodebb-plugin-emoji": "4.0.6",
         "nodebb-plugin-emoji-android": "3.0.0",


### PR DESCRIPTION
## Description

Instead of using the default composer plugin, we will instead track our own fork and make changes there so we could incorporate our data model changes into the post creation process. This PR will greatly help us to address user story #3.

Our own fork is maintained here:
https://github.com/yliang412/nodebb-plugin-composer-default/releases/tag/op-mod-v9.2.5

## Related issue

This PR closes #25. 

## Checklist

### Functional
N/A

### Testing, Style and Documentation

Cloned a new local repo and verified the duplicate discard button showed up.

<img width="1185" alt="Screenshot 2023-10-04 at 9 50 52 PM" src="https://github.com/CMU-313/fall23-nodebb-op/assets/70461588/28d42283-c7ac-4651-8d75-80474e41e29b">


**PLEASE SQUASH BEFORE MERGE!**
