### PR TITLE
Rename plugin to op for future setup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,8 +45,8 @@ module.exports = function (grunt) {
         if (!process.argv.includes('--core')) {
             await db.init();
             pluginList = await plugins.getActive();
-            if (!pluginList.includes('nodebb-plugin-composer-default')) {
-                pluginList.push('nodebb-plugin-composer-default');
+            if (!pluginList.includes('nodebb-plugin-composer-op')) {
+                pluginList.push('nodebb-plugin-composer-op');
             }
         }
 

--- a/install/package.json
+++ b/install/package.json
@@ -93,7 +93,7 @@
         "multiparty": "4.2.3",
         "nconf": "0.12.0",
         "nodebb-plugin-2factor": "5.1.2",
-        "nodebb-plugin-composer-default": "git://github.com/yliang412/nodebb-plugin-composer-default#op-mod-v9.2.5",
+        "nodebb-plugin-composer-op": "9.2.4",
         "nodebb-plugin-dbsearch": "5.1.5",
         "nodebb-plugin-emoji": "4.0.6",
         "nodebb-plugin-emoji-android": "3.0.0",

--- a/src/install.js
+++ b/src/install.js
@@ -491,7 +491,7 @@ async function enableDefaultPlugins() {
     console.log('Enabling default plugins');
 
     let defaultEnabled = [
-        'nodebb-plugin-composer-default',
+        'nodebb-plugin-composer-op',
         'nodebb-plugin-markdown',
         'nodebb-plugin-mentions',
         'nodebb-widget-essentials',

--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -223,8 +223,8 @@ exports.webpack = async function (options) {
     const plugins = require('../plugins/data');
 
     const activePlugins = (await plugins.getActive()).map(p => p.id);
-    if (!activePlugins.includes('nodebb-plugin-composer-default')) {
-        activePlugins.push('nodebb-plugin-composer-default');
+    if (!activePlugins.includes('nodebb-plugin-composer-op')) {
+        activePlugins.push('nodebb-plugin-composer-op');
     }
     await fs.promises.writeFile(path.resolve(__dirname, '../../build/active_plugins.json'), JSON.stringify(activePlugins));
 

--- a/test/mocks/databasemock.js
+++ b/test/mocks/databasemock.js
@@ -253,7 +253,7 @@ async function enableDefaultPlugins() {
     const defaultEnabled = [
         'nodebb-plugin-dbsearch',
         'nodebb-widget-essentials',
-        'nodebb-plugin-composer-default',
+        'nodebb-plugin-composer-op',
     ].concat(testPlugins);
 
     winston.info('[install/enableDefaultPlugins] activating default plugins', defaultEnabled);


### PR DESCRIPTION
Setup dependency to a forked repo of `nodebb-plugin-composer-default` that is created by us, team-op. 

Old Package : `nodebb-plugin-composer-default`
New package : `nodebb-plugin-composer-op` [composer-op on npm](https://www.npmjs.com/package/nodebb-plugin-composer-op) by @PeterNotFound114 

